### PR TITLE
Modified gistId PropType from number to string

### DIFF
--- a/index.js
+++ b/index.js
@@ -18,7 +18,7 @@ function adjustHeightWhenComplete(myFrame, myDoc) {
 var GistEmbed = React.createClass({
   displayName: 'GistEmbed',
   propTypes: {
-    gistId: PropTypes.number.isRequired
+    gistId: PropTypes.string.isRequired
   },
   componentDidMount: function() {
 


### PR DESCRIPTION
A gistId 'a759fd68208808020598' is a hexadecimal hash. So JavaScript is needs to interpret it as a string.
